### PR TITLE
enhancement: currency type are now decimal

### DIFF
--- a/BulkyBook.DataAccess/Migrations/20230219134510_ChangeCurrencyTypeFromDoubleToDecimal.Designer.cs
+++ b/BulkyBook.DataAccess/Migrations/20230219134510_ChangeCurrencyTypeFromDoubleToDecimal.Designer.cs
@@ -4,6 +4,7 @@ using BulkyBook.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BulkyBook.DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230219134510_ChangeCurrencyTypeFromDoubleToDecimal")]
+    partial class ChangeCurrencyTypeFromDoubleToDecimal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BulkyBook.DataAccess/Migrations/20230219134510_ChangeCurrencyTypeFromDoubleToDecimal.cs
+++ b/BulkyBook.DataAccess/Migrations/20230219134510_ChangeCurrencyTypeFromDoubleToDecimal.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BulkyBook.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeCurrencyTypeFromDoubleToDecimal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price50",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price100",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "ListPrice",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "OrderTotal",
+                table: "OrderHeaders",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Price",
+                table: "OrderDetail",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "Price50",
+                table: "Products",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "Price100",
+                table: "Products",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "Price",
+                table: "Products",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "ListPrice",
+                table: "Products",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "OrderTotal",
+                table: "OrderHeaders",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<double>(
+                name: "Price",
+                table: "OrderDetail",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+        }
+    }
+}

--- a/BulkyBook.Models/OrderDetail.cs
+++ b/BulkyBook.Models/OrderDetail.cs
@@ -11,9 +11,9 @@ namespace BulkyBook.Models
 {
     public class OrderDetail
     {
-        public int Id {  get; set; }
+        public int Id { get; set; }
         [Required]
-        public int OrderId {  get; set; }
+        public int OrderId { get; set; }
         [ForeignKey("OrderId")]
         [ValidateNever]
         public OrderHeader OrderHeader { get; set; }
@@ -24,6 +24,7 @@ namespace BulkyBook.Models
         [ValidateNever]
         public Product Product { get; set; }
         public int Count { get; set; }
-        public double Price { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Price { get; set; }
     }
 }

--- a/BulkyBook.Models/OrderHeader.cs
+++ b/BulkyBook.Models/OrderHeader.cs
@@ -20,7 +20,8 @@ namespace BulkyBook.Models
         [Required]
         public DateTime OrderDate { get; set; }
         public DateTime ShippingDate { get; set; }
-        public double OrderTotal { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal OrderTotal { get; set; }
         public string? OrderStatus { get; set; }
         public string? PaymentStatus { get; set; }
         public string? TrackingNumber { get; set; }

--- a/BulkyBook.Models/Product.cs
+++ b/BulkyBook.Models/Product.cs
@@ -22,21 +22,25 @@ namespace BulkyBook.Models
         [Required]
         [Range(1, 10000)]
         [Display(Name = "List Price")]
-        public double ListPrice { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal ListPrice { get; set; }
         [Required]
         [Range(1, 10000)]
         [Display(Name = "Price for 1-50")]
-        public double Price { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Price { get; set; }
 
         [Required]
         [Range(1, 10000)]
         [Display(Name = "Price for 51-100")]
-        public double Price50 { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Price50 { get; set; }
 
         [Required]
         [Display(Name = "Price for 100+")]
         [Range(1, 10000)]
-        public double Price100 { get; set; }
+        [Column(TypeName = "decimal(18,2)")]
+        public decimal Price100 { get; set; }
         [ValidateNever]
         public string ImageUrl { get; set; }
 

--- a/BulkyBook.Models/ShoppingCart.cs
+++ b/BulkyBook.Models/ShoppingCart.cs
@@ -26,6 +26,6 @@ namespace BulkyBook.Models
         public ApplicationUser ApplicationUser { get; set; }
 
         [NotMapped]
-        public double Price { get; set; }
+        public decimal Price { get; set; }
     }
 }

--- a/BulkyBookWeb/Areas/Customer/Controllers/CartController.cs
+++ b/BulkyBookWeb/Areas/Customer/Controllers/CartController.cs
@@ -243,7 +243,7 @@ namespace BulkyBookWeb.Areas.Customer.Controllers
 
 
 
-        private double GetPriceBasedOnQuantity(double quantity, double price, double price50, double price100)
+        private decimal GetPriceBasedOnQuantity(double quantity, decimal price, decimal price50, decimal price100)
         {
             if (quantity <= 50)
             {


### PR DESCRIPTION
### tl;dr;
Replace currency type from double to decimal and add a new migration

Models affected

- OrderDerail
- OrderHeader
- Product
- ShoppingCart

# Reason

On this [doc](https://learn.microsoft.com/en-us/dotnet/api/system.decimal?redirectedfrom=MSDN&view=net-7.0#remarks)  decimal datatype are appropriate for financial calculations.  

Even though it's an educational application, I believe it's highly valuable to utilize data types that are commonly used in production environments

